### PR TITLE
Update rubygems before installing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ rvm:
   - ree
   - 1.9.3
   - jruby
+before_install:
+  - gem update --system


### PR DESCRIPTION
REE and JRuby ship with RubyGems 1.8.9 that are not compatible with Rails 3.2. We [recommend](http://about.travis-ci.org/docs/user/languages/ruby/)
people to do this because older versions of Rails seem to work just as well with 1.8.15.
