### PR TITLE
Adjust the code to accept any default i18n date format.

### DIFF
--- a/lib/i18n_alchemy/date_parser.rb
+++ b/lib/i18n_alchemy/date_parser.rb
@@ -20,7 +20,11 @@ module I18n
       protected
 
       def build_object(parsed_date)
-        Date.new(*parsed_date.values_at(:year, :mon, :mday))
+        Date.new(*extract_date(parsed_date))
+      end
+
+      def extract_date(parsed_date)
+        [parsed_date[:year], parsed_date[:mon], parsed_date[:mday]].compact
       end
 
       def i18n_format

--- a/test/i18n_alchemy/date_parser_test.rb
+++ b/test/i18n_alchemy/date_parser_test.rb
@@ -20,6 +20,12 @@ class DateParserTest < MiniTest::Unit::TestCase
     end
   end
 
+  def test_parsers_string_dates_on_different_i18n_locale
+    I18n.with_locale :jp do
+      assert_equal "2011-12-01", @parser.parse("12/2011")
+    end
+  end
+
   def test_parsers_returns_the_given_string_when_invalid_date
     assert_equal "31/12/2011", @parser.parse("31/12/2011")
   end
@@ -35,6 +41,12 @@ class DateParserTest < MiniTest::Unit::TestCase
   def test_localizes_date_values_based_on_current_i18n_locale
     I18n.with_locale :pt do
       assert_equal "31/12/2011", @parser.localize(@date)
+    end
+  end
+
+  def test_localizes_date_values_based_on_different_i18n_locale
+    I18n.with_locale :jp do
+      assert_equal "12/2011", @parser.localize(@date)
     end
   end
 end

--- a/test/locale/jp.yml
+++ b/test/locale/jp.yml
@@ -1,0 +1,15 @@
+jp:
+
+  date:
+    formats:
+      default: "%m/%Y"
+
+  time:
+    formats:
+      default: "%d/%m/%Y %H:%M:%S"
+
+  number:
+    format:
+      separator: ','
+      delimiter: '.'
+      precision: 2


### PR DESCRIPTION
Hi! In our projects, the default format of date is a little different, we use `%m/%Y`. So, the different format breaks in your gem.

With this refactoring, we can use any format of date.
