### PR TITLE
Hardwire `to_json` implementation.

### DIFF
--- a/lib/i18n_alchemy/proxy.rb
+++ b/lib/i18n_alchemy/proxy.rb
@@ -27,6 +27,12 @@ module I18n
         @target.to_param
       end
 
+      # Override to_json to always call +to_json+ on the target object, instead of
+      # serializing the proxy object, that may issue circular references on Ruby 1.8.
+      def to_json(options = nil)
+        @target.to_json(options)
+      end
+
       # Override to_model to always return the proxy, otherwise it returns the
       # target object. This allows us to integrate with action view.
       def to_model

--- a/test/i18n_alchemy/proxy_test.rb
+++ b/test/i18n_alchemy/proxy_test.rb
@@ -26,6 +26,11 @@ class ProxyTest < I18n::Alchemy::ProxyTestCase
     assert_equal 1, @localized.id
   end
 
+  def test_to_json
+    @supplier.products << @product
+    assert_equal @supplier.to_json, @supplier_localized.to_json
+  end
+
   def test_to_param
     assert_equal @product.to_param, @localized.to_param
   end


### PR DESCRIPTION
Issue found when serializing some proxied AR instances to JSON. We couldn't drill down the problem inside ActiveSupport serialization process :cry:.
