### PR TITLE
Rails 4.2.1 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord',  '~> 4.2.1'
-gem 'activesupport', '~> 4.2.1'
+gem 'activerecord',  '< 5.0.0'
+gem 'activesupport', '< 5.0.0'
 
 platform :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord',  '~> 4.2.0'
-gem 'activesupport', '~> 4.2.0'
+gem 'activerecord',  '~> 4.2.1'
+gem 'activesupport', '~> 4.2.1'
 
 platform :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.0'

--- a/i18n_alchemy.gemspec
+++ b/i18n_alchemy.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
   s.test_files    = Dir["test/**/*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "activesupport", ">= 3.2.0", "<= 4.2.0"
+  s.add_dependency "activesupport", ">= 3.2.0", "<= 4.2.1"
   s.add_dependency "i18n", "~> 0.6"
 
-  s.add_development_dependency "actionpack", ">= 3.2.0", "<= 4.2.0"
-  s.add_development_dependency "activerecord", ">= 3.2.0", "<= 4.2.0"
+  s.add_development_dependency "actionpack", ">= 3.2.0", "<= 4.2.1"
+  s.add_development_dependency "activerecord", ">= 3.2.0", "<= 4.2.1"
   s.add_development_dependency "minitest", ">= 4.3.2"
   s.add_development_dependency "rake", "~> 10.1"
 end

--- a/i18n_alchemy.gemspec
+++ b/i18n_alchemy.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
   s.test_files    = Dir["test/**/*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "activesupport", ">= 3.2.0", "<= 4.2.1"
+  s.add_dependency "activesupport", ">= 3.2.0", "< 5.0.0"
   s.add_dependency "i18n", "~> 0.6"
 
-  s.add_development_dependency "actionpack", ">= 3.2.0", "<= 4.2.1"
-  s.add_development_dependency "activerecord", ">= 3.2.0", "<= 4.2.1"
+  s.add_development_dependency "actionpack", ">= 3.2.0", "< 5.0.0"
+  s.add_development_dependency "activerecord", ">= 3.2.0", "< 5.0.0"
   s.add_development_dependency "minitest", ">= 4.3.2"
   s.add_development_dependency "rake", "~> 10.1"
 end

--- a/lib/i18n_alchemy/proxy.rb
+++ b/lib/i18n_alchemy/proxy.rb
@@ -46,6 +46,7 @@ module I18n
       # Allow calling localized methods with :send. This allows us to integrate
       # with action view methods.
       alias :send :__send__
+      alias :public_send :__send__
 
       # Allow calling localized methods with :try. If the method is not declared
       # here, it'll be delegated to the target, losing localization capabilities.


### PR DESCRIPTION
Fix this issue #36.

Alias `public_send` to `__send__` allowing ActionView 4.2.1+ support.

Rails ActionView commit that caused test fail:
https://github.com/rails/rails/commit/f0570a3d3fa85ba0153d61c90bad6db648144256

Let me know if i need improve something.