### PR TITLE
Update dependency of i18n to a bit latest version

### DIFF
--- a/i18n_alchemy.gemspec
+++ b/i18n_alchemy.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "activesupport", ">= 3.2.0", "< 5.3.0"
-  s.add_dependency "i18n", "~> 0.6"
+  s.add_dependency "i18n", ">= 0.7"
 
   s.add_development_dependency "actionpack", ">= 3.2.0", "< 5.3.0"
   s.add_development_dependency "activerecord", ">= 3.2.0", "< 5.3.0"


### PR DESCRIPTION
Many other projects had upgraded their dependencies for `i18n` gem. So with that lower version of the gem it didn't worked with others. 

```
Bundler could not find compatible versions for gem "i18n":
  In snapshot (Gemfile.lock):
    i18n (= 1.0.1)

  In Gemfile:
    capistrano-rails (>= 1.3.1, ~> 1.3) was resolved to 1.3.1, which depends on
      capistrano (~> 3.1) was resolved to 3.10.2, which depends on
        i18n

    faker (>= 1.8.7, ~> 1.8) was resolved to 1.8.7, which depends on
      i18n (>= 0.7)

    i18n_alchemy was resolved to 0.2.4, which depends on
      i18n (~> 0.6)

    money-rails (~> 1.10) was resolved to 1.11.0, which depends on
      money (~> 6.11.0) was resolved to 6.11.0, which depends on
        i18n (< 1.1, >= 0.6.4)

    rails-i18n (>= 5.0.4, ~> 5.0) was resolved to 5.1.1, which depends on
      i18n (< 2, >= 0.7)
```