### PR TITLE
Add alias for new `update`/`update!` methods in Rails

### DIFF
--- a/lib/i18n_alchemy/attributes_parsing.rb
+++ b/lib/i18n_alchemy/attributes_parsing.rb
@@ -10,11 +10,19 @@ module I18n
       end
 
       def update_attributes(attributes)
-        @target.update_attributes(parse_attributes(attributes))
+        @target.update(parse_attributes(attributes))
       end
 
       def update_attributes!(attributes)
-        @target.update_attributes!(parse_attributes(attributes))
+        @target.update!(parse_attributes(attributes))
+      end
+
+      def update(attributes)
+        @target.update(parse_attributes(attributes))
+      end
+
+      def update!(attributes)
+        @target.update!(parse_attributes(attributes))
       end
 
       def update_attribute(attribute, value)

--- a/test/i18n_alchemy/proxy/attributes_parsing_test.rb
+++ b/test/i18n_alchemy/proxy/attributes_parsing_test.rb
@@ -59,6 +59,18 @@ class ProxyAttributesParsingTest < I18n::Alchemy::ProxyTestCase
     assert_equal 2.88, @product.reload.price
   end
 
+  def test_update!
+    @localized.update!(:price => '2,88')
+    assert_equal '2,88', @localized.price
+    assert_equal 2.88, @product.reload.price
+  end
+
+  def test_update
+    @localized.update(:price => '2,88')
+    assert_equal '2,88', @localized.price
+    assert_equal 2.88, @product.reload.price
+  end
+
   def test_update_attributes_bang_does_not_change_given_attributes_hash
     assert_attributes_hash_is_unchanged do |attributes|
       @localized.update_attributes!(attributes)


### PR DESCRIPTION
In Rails 5.2 `update_attributes` has been renamed to `update` and `update_attributes` is now an alias to `update` (same for the ! version). Added respective methods in i18n_alchemy to reflect these changes.