### PR TITLE
README: remove custom_parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ And then just configure the attribute you want to use with this new parser:
 ```ruby
 class Product < ActiveRecord::Base
   include I18n::Alchemy
-  custom_parsers :released_month => MyCustomDateParser
+  localize :released_month, :using => MyCustomDateParser
 end
 ```
 


### PR DESCRIPTION
the custom_parsers method is no longer available so it should be removed from the documentation.
