### PR TITLE
Bugfix: association_parser

### DIFF
--- a/lib/i18n_alchemy/association_parser.rb
+++ b/lib/i18n_alchemy/association_parser.rb
@@ -19,7 +19,7 @@ module I18n
       #
       def parse(attributes)
         if association.macro == :has_many
-          attributes = attributes.is_a?(Hash) ? attributes.values : attributes
+          attributes = attributes.is_a?(Hash) || attributes.is_a?(ActionController::Parameters) ? attributes.values : attributes
           attributes.map { |value_attributes| proxy.send(:parse_attributes, value_attributes) }
         else
           proxy.send(:parse_attributes, attributes)


### PR DESCRIPTION
In PR #44 the requrest is to cast the AC::Parameters to a hash. This is not needed, since AC::Parameters has a values call that delegates it to the @parameters variable. The variable is a ActiveSupport::HashWithIndifferentAccess, which has a values method. 
So the only thing that needs to be done is extend the conditional to check if the attributes variable is AC::Parameters object. 

Another option would be to change the conditional to see of the attributes objec respond_to?(:values) 