### PR TITLE
Remove deprecations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 gem 'activerecord',  '~> 7.0.0'
 gem 'activesupport', '~> 7.0.0'
+gem 'concurrent-ruby', '~> 1.3.4'    
 
 platform :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.0'

--- a/Gemfile-rails.5.2.x
+++ b/Gemfile-rails.5.2.x
@@ -4,6 +4,7 @@ gemspec
 
 gem 'activerecord',  '~> 5.2.0'
 gem 'activesupport', '~> 5.2.0'
+gem 'concurrent-ruby', '~> 1.3.4'    
 
 platform :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.0'

--- a/Gemfile-rails.6.0.x
+++ b/Gemfile-rails.6.0.x
@@ -4,6 +4,7 @@ gemspec
 
 gem 'activerecord',  '~> 6.0.0'
 gem 'activesupport', '~> 6.0.0'
+gem 'concurrent-ruby', '~> 1.3.4'    
 
 platform :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.0'

--- a/Gemfile-rails.6.1.x
+++ b/Gemfile-rails.6.1.x
@@ -4,6 +4,7 @@ gemspec
 
 gem 'activerecord',  '~> 6.1.0'
 gem 'activesupport', '~> 6.1.0'
+gem 'concurrent-ruby', '1.3.4'    
 
 platform :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.0'

--- a/lib/i18n_alchemy/proxy.rb
+++ b/lib/i18n_alchemy/proxy.rb
@@ -1,8 +1,14 @@
 module I18n
   module Alchemy
     # Depend on AS::Basic/ProxyObject which has a "blank slate" - no methods.
-    base_proxy = defined?(ActiveSupport::ProxyObject) ?
-      ActiveSupport::ProxyObject : ActiveSupport::BasicObject
+    base_proxy =
+      if defined?(BasicObject)
+        BasicObject
+      elsif defined?(ActiveSupport::ProxyObject)
+        ActiveSupport::ProxyObject
+      else
+        ActiveSupport::BasicObject
+      end
 
     class Proxy < base_proxy
       include AttributesParsing

--- a/lib/i18n_alchemy/proxy.rb
+++ b/lib/i18n_alchemy/proxy.rb
@@ -63,15 +63,12 @@ module I18n
       # Delegate all method calls that are not translated to the target object.
       # As the proxy does not have any other method, there is no need to
       # override :respond_to, just delegate it to the target as well.
+      def method_missing(*args, &block)
+        @target.send(*args, &block)
+      end
+
       if ::RUBY_VERSION >= "2.7"
-        def method_missing(*args, **kwargs, &block)
-          @target.send(*args, **kwargs, &block)
-        end
         ruby2_keywords :method_missing
-      else
-        def method_missing(*args, &block)
-          @target.send(*args, &block)
-        end
       end
 
       private


### PR DESCRIPTION
Remove the following warnings:

* Rails 8 compatibility deprecation: 
  * `DEPRECATION WARNING: ActiveSupport::ProxyObject is deprecated and will be removed in Rails 8.0.                                                                                         
Use Ruby's built-in BasicObject instead.                                                                                                                                                
 (called from <main> at /home/aron/fortytools/skippr/config/application.rb:11) `
  * This would create make the gem fail on rails 8.

*
  * `/home/aron/.asdf/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/i18n_alchemy-0.5.0/lib/i18n_alchemy/proxy.rb:64: warning: Skipping set of ruby2_keywords flag for method_missing (method a
ccepts keywords or method does not accept argument splat)`
  * This is not really a problem but anoying. It was caused by a wrong usage of the `ruby2_keywords` method
