### PR TITLE
Fix association parser with ActionController::Parameters

### DIFF
--- a/lib/i18n_alchemy/association_parser.rb
+++ b/lib/i18n_alchemy/association_parser.rb
@@ -19,8 +19,11 @@ module I18n
       #
       def parse(attributes)
         if association.macro == :has_many
-          attributes = attributes.is_a?(Hash) ? attributes.values : attributes
-          attributes.map { |value_attributes| proxy.send(:parse_attributes, value_attributes) }
+          if attributes.respond_to?(:transform_values)
+            attributes.transform_values { |value_attributes| proxy.send(:parse_attributes, value_attributes) }
+          else
+            attributes.map { |value_attributes| proxy.send(:parse_attributes, value_attributes) }
+          end
         else
           proxy.send(:parse_attributes, attributes)
         end

--- a/lib/i18n_alchemy/association_parser.rb
+++ b/lib/i18n_alchemy/association_parser.rb
@@ -20,12 +20,12 @@ module I18n
       def parse(attributes)
         if association.macro == :has_many
           if attributes.respond_to?(:transform_values)
-            attributes.transform_values { |value_attributes| proxy.send(:parse_attributes, value_attributes) }
+            attributes.transform_values { |value_attributes| parse_attributes(value_attributes) }
           else
-            attributes.map { |value_attributes| proxy.send(:parse_attributes, value_attributes) }
+            attributes.map { |value_attributes| parse_attributes(value_attributes) }
           end
         else
-          proxy.send(:parse_attributes, attributes)
+          parse_attributes(attributes)
         end
       end
 
@@ -50,6 +50,10 @@ module I18n
 
       def proxy
         @proxy ||= @association.klass.new.localized
+      end
+
+      def parse_attributes(attributes)
+        proxy.send(:parse_attributes, attributes)
       end
     end
   end

--- a/test/i18n_alchemy/proxy/attributes_parsing_test.rb
+++ b/test/i18n_alchemy/proxy/attributes_parsing_test.rb
@@ -80,7 +80,18 @@ class ProxyAttributesParsingTest < I18n::Alchemy::ProxyTestCase
   end
 
   def test_assign_attributes_for_nested_attributes_passing_a_hash_for_collection_with_unique_keys
-    @supplier_localized.assign_attributes(products_attributes: { '0' => { price: '2,93', _destroy: 'false' }, '1' => { price: '2,85', _destroy: 'false' }})
+    @supplier_localized.assign_attributes(
+      products_attributes: { '0' => { price: '2,93', _destroy: 'false' }, '1' => { price: '2,85', _destroy: 'false' }}
+    )
+    prices = @supplier.products.map { |p| p.localized.price }.sort
+    assert_equal ['2,85', '2,93'], prices
+  end
+
+  def test_assign_attributes_for_nested_attributes_passing_a_hash_for_collection_with_unique_keys_using_ac_parameters
+    parameters = ActionController::Parameters.new(
+      products_attributes: { '0' => { price: '2,93', _destroy: 'false' }, '1' => { price: '2,85', _destroy: 'false' }}
+    )
+    @supplier_localized.assign_attributes(parameters.permit!)
     prices = @supplier.products.map { |p| p.localized.price }.sort
     assert_equal ['2,85', '2,93'], prices
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require 'minitest'
 require 'minitest/autorun'
 
 require "i18n_alchemy"
+require "action_controller"
 require "action_view"
 require "active_record"
 


### PR DESCRIPTION
Before Rails 5, AC::Parameters inherited from HashWithIndifferentAccess, so it was basically considered a Hash. However since Rails 5 that is not the case, and this check was totally failing for nested attributes / associations.

In order to handle AC::Parameters correctly, we need to check for it besides the Hash, so we could in theory add another `is_a?` check.

That said, I noticed we were changing the parameters here from a Hash to an Array, effectively changing the behavior when parsing through the params, by not passing along the hash with unique keys we received.

So instead of just adding that check, I'm actually changing to check for `transform_values`, which is a method Rails implements on all Hash / AC::Parameters objects, so that we can parse the incoming params (Hash or Array) and return back the same type of object, only touching the attributes/values we need to localize in the process.

Closes https://github.com/carlosantoniodasilva/i18n_alchemy/pull/60
Closes https://github.com/carlosantoniodasilva/i18n_alchemy/pull/44
Closes https://github.com/carlosantoniodasilva/i18n_alchemy/issues/53